### PR TITLE
Add more manifest metadata

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,6 +2,8 @@
   "id": "com.mattermost.welcomebot",
   "name": "Welcome Bot",
   "description": "This plugin adds a WelcomeBot that helps add new users to channels.",
+  "homepage_url": "https://github.com/mattermost/mattermost-plugin-welcomebot",
+  "support_url": "https://github.com/mattermost/mattermost-plugin-welcomebot/issues",
   "version": "1.1.1",
   "min_server_version": "5.12.0",
   "server": {


### PR DESCRIPTION
#### Summary
Add `homepage_url` and `support_url` to the manifest. `support_url` is not jet used in the webapp, but there is no downside of defining it already.

I've tested the changes locally and can confirm that the link to the `homepage_url` is correctly shown.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21918
