### PR TITLE
[GH-26] Implement welcome messages preview

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-server/v5/plugin"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+)
+
+const COMMAND_HELP = `* |/welcomebot preview [team-name] [user-name]| - preview the welcome message for the given team name. The current user's username will be used to render the template.
+* |/welcomebot list| - list the teams for which welcome messages were defined`
+
+func getCommand() *model.Command {
+	return &model.Command{
+		Trigger:          "welcomebot",
+		DisplayName:      "welcomebot",
+		Description:      "Welcome Bot helps adding new team members to channels.",
+		AutoComplete:     true,
+		AutoCompleteDesc: "Available commands: preview, help",
+		AutoCompleteHint: "[command]",
+	}
+}
+
+func (p *Plugin) postCommandResponse(args *model.CommandArgs, text string) {
+	post := &model.Post{
+		UserId:    p.botUserID,
+		ChannelId: args.ChannelId,
+		Message:   text,
+	}
+	_ = p.API.SendEphemeralPost(args.UserId, post)
+}
+
+func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	split := strings.Fields(args.Command)
+	command := split[0]
+	parameters := []string{}
+	action := ""
+	if len(split) > 1 {
+		action = split[1]
+	}
+	if len(split) > 2 {
+		parameters = split[2:]
+	}
+
+	if command != "/welcomebot" {
+		return &model.CommandResponse{}, nil
+	}
+
+	switch action {
+	case "preview":
+		if len(parameters) != 1 {
+			p.postCommandResponse(args, "Please specify a team, for which preview should be made.")
+			return &model.CommandResponse{}, nil
+		}
+
+		teamName := parameters[0]
+
+		found := false
+		for _, message := range p.getWelcomeMessages() {
+			if message.TeamName == teamName {
+				if err := p.previewWelcomeMessage(teamName, args, *message); err != nil {
+					errMsg := fmt.Sprintf("error occured while processing greeting for team `%s`: `%s`", teamName, err)
+					p.postCommandResponse(args, errMsg)
+					return &model.CommandResponse{}, nil
+				}
+
+				found = true
+			}
+		}
+
+		if !found {
+			p.postCommandResponse(args, fmt.Sprintf("team `%s` has not been found", teamName))
+		}
+		return &model.CommandResponse{}, nil
+	case "list":
+		if len(parameters) > 0 {
+			p.postCommandResponse(args, "List command does not accept any extra parameters")
+			return &model.CommandResponse{}, nil
+		}
+
+		wecomeMessages := p.getWelcomeMessages()
+
+		if len(wecomeMessages) == 0 {
+			p.postCommandResponse(args, "There are no welcome messages defined")
+			return &model.CommandResponse{}, nil
+		}
+
+		// Deduplicate entries
+		teams := make(map[string]struct{})
+		for _, message := range wecomeMessages {
+			teams[message.TeamName] = struct{}{}
+		}
+
+		var str strings.Builder
+		str.WriteString("Teams for which welcome messages are defined:")
+		for team := range teams {
+			str.WriteString(fmt.Sprintf("\n * %s", team))
+		}
+		p.postCommandResponse(args, str.String())
+		return &model.CommandResponse{}, nil
+	case "help":
+		text := "###### Mattermost welcomebot Plugin - Slash Command Help\n" + strings.Replace(COMMAND_HELP, "|", "`", -1)
+		p.postCommandResponse(args, text)
+		return &model.CommandResponse{}, nil
+	case "":
+		text := "###### Mattermost welcomebot Plugin - Slash Command Help\n" + strings.Replace(COMMAND_HELP, "|", "`", -1)
+		p.postCommandResponse(args, text)
+		return &model.CommandResponse{}, nil
+	}
+
+	p.postCommandResponse(args, fmt.Sprintf("Unknown action %v", action))
+
+	return &model.CommandResponse{}, nil
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -37,5 +37,7 @@ func (p *Plugin) OnActivate() error {
 	}
 	p.botUserID = botUserID
 
+	p.API.RegisterCommand(getCommand())
+
 	return nil
 }


### PR DESCRIPTION
#### Summary

This PR implements following bot commands:
* `/welocmebot help` - show a short usage information
* `/welcomebot list` - lists the teams for which greetings were defined
* `/welcomebot preview [team-name]` - sends ephemeral messages to the user with the preview of the welcome message[s] for the given team name and the user that requested preview

Please see below for the screenshots of the conversation with the bot. I have used the sample configuration for the plugin's README.md file, and only adjusted the team names to match the ones generated by `make sample-data` target in mm-server.
* `/welcomebot help`
![cmd-help](https://user-images.githubusercontent.com/2124609/74110522-99bd1880-4b8d-11ea-8175-012e139161ab.png)
* `/welcomebot list`
![cmd-list](https://user-images.githubusercontent.com/2124609/74110525-9d509f80-4b8d-11ea-8937-64df5dd35d83.png)
* `/welcomebot preview ad-1`
![cmd-prev-ad-1](https://user-images.githubusercontent.com/2124609/74110532-a6417100-4b8d-11ea-86cf-c40aefeb5111.png)
* `/welcomebot preview reiciendis-0`
![cmd-prev-reiciendis-0](https://user-images.githubusercontent.com/2124609/74110535-ab062500-4b8d-11ea-802f-812577e152c3.png)

Should we limit the previews to the server's sysadmin? I think the greeting messages may be confidential, but wanted to double-check.

#### Ticket Link

  Fixes https://github.com/mattermost/mattermost-plugin-welcomebot/issues/26
