### PR TITLE
[GH-44] Remove `user-name` option preview text

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
-const COMMAND_HELP = `* |/welcomebot preview [team-name] [user-name]| - preview the welcome message for the given team name. The current user's username will be used to render the template.
+const COMMAND_HELP = `* |/welcomebot preview [team-name] | - preview the welcome message for the given team name. The current user's username will be used to render the template.
 * |/welcomebot list| - list the teams for which welcome messages were defined
 * |/welcomebot set_channel_welcome [welcome-message]| - set the welcome message for the given channel. Direct channels are not supported.
 * |/welcomebot get_channel_welcome| - print the welcome message set for the given channel (if any)


### PR DESCRIPTION
#### Summary
The issue was found because the help text suggested you can pass in a `user-name` along with a `team-name`.  There is no reason to pass in a user-name to the preview command because the command uses the current users name to preview the message.

The proposal is to remove the options as described in the help text.

#### Ticket Link
Fixes: #44 