### PR TITLE
[GH-41] Restrict Channel specific Welcome Bot message config to users who have permission to manage channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To configure the Welcome Bot, edit your `config.json` file with a message you wa
 ```
         "Plugins": {
             "com.mattermost.welcomebot": {
+                "GlobalWelcomeMessage": "Global Welcome Message"
                 "WelcomeMessages": [
                     {
                         "TeamName": "your-team-name",
@@ -75,10 +76,10 @@ where
     - **ChannelsAddedTo**: List of channel names the user is added to. Must be the channel handle used in the URL, in lowercase. For example, in the following URL the **channel name** value is `my-channel`: https://example.com/my-team/channels/my-channel
 
 The preview of the configured messages, as well as the creation of a channel welcome message, can be done via bot commands:
-* `/welcomebot help` - Displays usage information.
+* `/welcomebot help` - Displays usage information. The following commands will only allowed to be run by system admins and users with permissions to manage channel roles. `set_channel_welcome`, `get_channel_welcome` and `delete_channel_welcome`
 * `/welcomebot list` - Lists the teams for which greetings were defined.
 * `/welcomebot preview [team-name]` - Sends ephemeral messages to the user calling the command, with the preview of the welcome message[s] for the given team name and the user that requested the preview.
-* `/welcomebot set_channel_welcome [welcome-message]` - Sets the given text as current's channel welcome message.
+* `/welcomebot set_channel_welcome [welcome-message]` - Sets the given text as current's channel welcome message. 
 * `/welcomebot get_channel_welcome` - Gets the current channel's welcome message.
 * `/welcomebot delete_channel_welcome` - Deletes the current channel's welcome message.
 

--- a/server/command.go
+++ b/server/command.go
@@ -230,16 +230,16 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 			p.postCommandResponse(args, "/%s commands can only be executed by the user with channel admin role", action)
 			return &model.CommandResponse{}, nil
 		}
-	} else {
-		isSysadmin, err := p.hasSysadminRole(args.UserId)
-		if err != nil {
-			p.postCommandResponse(args, "authorization failed: %s", err)
-			return &model.CommandResponse{}, nil
-		}
-		if !isSysadmin {
-			p.postCommandResponse(args, "/welcomebot commands can only be executed by the user with system admin role")
-			return &model.CommandResponse{}, nil
-		}
+	}
+
+	isSysadmin, err := p.hasSysadminRole(args.UserId)
+	if err != nil {
+		p.postCommandResponse(args, "authorization failed: %s", err)
+		return &model.CommandResponse{}, nil
+	}
+	if !isSysadmin {
+		p.postCommandResponse(args, "/welcomebot commands can only be executed by the user with system admin role")
+		return &model.CommandResponse{}, nil
 	}
 
 	switch action {

--- a/server/command.go
+++ b/server/command.go
@@ -57,17 +57,6 @@ func (p *Plugin) hasSysadminRole(userID string) (bool, error) {
 	return true, nil
 }
 
-func (p *Plugin) hasChannelAdminRole(channelID string, userID string) (bool, error) {
-	channel, err := p.API.GetChannel(channelID)
-	if err != nil {
-		return false, err
-	}
-	if channel.CreatorId != userID {
-		return false, nil
-	}
-	return true, nil
-}
-
 func (p *Plugin) validateCommand(action string, parameters []string) string {
 	switch action {
 	case commandTriggerPreview:
@@ -221,11 +210,8 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 	}
 
 	if action == commandTriggerSetChannelWelcome || action == commandTriggerGetChannelWelcome || action == commandTriggerDeleteChannelWelcome {
-		isChannelAdmin, err := p.hasChannelAdminRole(args.ChannelId, args.UserId)
-		if err != nil {
-			p.postCommandResponse(args, "authorization failed: %s", err)
-			return &model.CommandResponse{}, nil
-		}
+		isChannelAdmin := p.API.HasPermissionToChannel(args.UserId, args.ChannelId, model.PERMISSION_MANAGE_SLASH_COMMANDS)
+
 		if !isChannelAdmin {
 			p.postCommandResponse(args, "/%s commands can only be executed by the user with channel admin role", action)
 			return &model.CommandResponse{}, nil

--- a/server/command.go
+++ b/server/command.go
@@ -210,10 +210,10 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 	}
 
 	if action == commandTriggerSetChannelWelcome || action == commandTriggerGetChannelWelcome || action == commandTriggerDeleteChannelWelcome {
-		isChannelAdmin := p.API.HasPermissionToChannel(args.UserId, args.ChannelId, model.PERMISSION_MANAGE_SLASH_COMMANDS)
+		hasPermissionTo := p.API.HasPermissionToChannel(args.UserId, args.ChannelId, model.PERMISSION_MANAGE_SLASH_COMMANDS)
 
-		if !isChannelAdmin {
-			p.postCommandResponse(args, "/%s commands can only be executed by the user with channel admin role", action)
+		if !hasPermissionTo {
+			p.postCommandResponse(args, "/%s commands can only be executed by the user with permissions to manage the slash commands", action)
 			return &model.CommandResponse{}, nil
 		}
 	}

--- a/server/command.go
+++ b/server/command.go
@@ -209,23 +209,21 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 		return &model.CommandResponse{}, nil
 	}
 
-	if action == commandTriggerSetChannelWelcome || action == commandTriggerGetChannelWelcome || action == commandTriggerDeleteChannelWelcome {
-		hasPermissionTo := p.API.HasPermissionToChannel(args.UserId, args.ChannelId, model.PERMISSION_MANAGE_SLASH_COMMANDS)
-
-		if !hasPermissionTo {
-			p.postCommandResponse(args, "/%s commands can only be executed by the user with permissions to manage the slash commands", action)
-			return &model.CommandResponse{}, nil
-		}
-	}
-
 	isSysadmin, err := p.hasSysadminRole(args.UserId)
 	if err != nil {
 		p.postCommandResponse(args, "authorization failed: %s", err)
 		return &model.CommandResponse{}, nil
 	}
+
 	if !isSysadmin {
-		p.postCommandResponse(args, "/welcomebot commands can only be executed by the user with system admin role")
-		return &model.CommandResponse{}, nil
+		if action == commandTriggerSetChannelWelcome || action == commandTriggerGetChannelWelcome || action == commandTriggerDeleteChannelWelcome {
+			hasPermissionTo := p.API.HasPermissionToChannel(args.UserId, args.ChannelId, model.PERMISSION_MANAGE_CHANNEL_ROLES)
+
+			if !hasPermissionTo {
+				p.postCommandResponse(args, "/%s commands can only be executed by the user with permissions to manage the slash commands", action)
+				return &model.CommandResponse{}, nil
+			}
+		}
 	}
 
 	switch action {

--- a/server/command.go
+++ b/server/command.go
@@ -57,6 +57,17 @@ func (p *Plugin) hasSysadminRole(userID string) (bool, error) {
 	return true, nil
 }
 
+func (p *Plugin) hasChannelAdminRole(channelID string, userID string) (bool, error) {
+	channel, err := p.API.GetChannel(channelID)
+	if err != nil {
+		return false, err
+	}
+	if channel.CreatorId != userID {
+		return false, nil
+	}
+	return true, nil
+}
+
 func (p *Plugin) validateCommand(action string, parameters []string) string {
 	switch action {
 	case commandTriggerPreview:
@@ -209,14 +220,26 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 		return &model.CommandResponse{}, nil
 	}
 
-	isSysadmin, err := p.hasSysadminRole(args.UserId)
-	if err != nil {
-		p.postCommandResponse(args, "authorization failed: %s", err)
-		return &model.CommandResponse{}, nil
-	}
-	if !isSysadmin {
-		p.postCommandResponse(args, "/welcomebot commands can only be executed by the user with system admin role")
-		return &model.CommandResponse{}, nil
+	if action == commandTriggerSetChannelWelcome || action == commandTriggerGetChannelWelcome || action == commandTriggerDeleteChannelWelcome {
+		isChannelAdmin, err := p.hasChannelAdminRole(args.ChannelId, args.UserId)
+		if err != nil {
+			p.postCommandResponse(args, "authorization failed: %s", err)
+			return &model.CommandResponse{}, nil
+		}
+		if !isChannelAdmin {
+			p.postCommandResponse(args, "/%s commands can only be executed by the user with channel admin role", action)
+			return &model.CommandResponse{}, nil
+		}
+	} else {
+		isSysadmin, err := p.hasSysadminRole(args.UserId)
+		if err != nil {
+			p.postCommandResponse(args, "authorization failed: %s", err)
+			return &model.CommandResponse{}, nil
+		}
+		if !isSysadmin {
+			p.postCommandResponse(args, "/welcomebot commands can only be executed by the user with system admin role")
+			return &model.CommandResponse{}, nil
+		}
 	}
 
 	switch action {

--- a/server/command.go
+++ b/server/command.go
@@ -220,7 +220,7 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 			hasPermissionTo := p.API.HasPermissionToChannel(args.UserId, args.ChannelId, model.PERMISSION_MANAGE_CHANNEL_ROLES)
 
 			if !hasPermissionTo {
-				p.postCommandResponse(args, "/%s commands can only be executed by the user with permissions to manage the slash commands", action)
+				p.postCommandResponse(args, "The `/welcomebot %s` command can only be executed by system admins and channel admins.", action)
 				return &model.CommandResponse{}, nil
 			}
 		}


### PR DESCRIPTION
#### Summary
Adds Restriction to Channel Messages 
#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-welcomebot/issues/41
