### PR TITLE
[mm-65] Allows users to add multiple teams to the messages using `team-a,team-b` in the messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To configure the Welcome Bot, edit your `config.json` file with a message you wa
             "com.mattermost.welcomebot": {
                 "WelcomeMessages": [
                     {
-                        "TeamName": "your-team-name",
+                        "TeamName": "your-team-name, your-second-team-name",
                         "DelayInSeconds": 3,
                         "Message": [
                             "Your welcome message here. Each list item specifies one line in the message text."
@@ -63,7 +63,7 @@ To configure the Welcome Bot, edit your `config.json` file with a message you wa
 
 where
 
-- **TeamName**: The team for which the Welcome Bot sends a message for. Must be the team handle used in the URL, in lowercase. For example, in the following URL the **TeamName** value is `my-team`: https://example.com/my-team/channels/my-channel
+- **TeamName**: - **TeamName**: The teams for which the Welcome Bot sends a message for. Must be the team handle used in the URL, in lowercase. For example, in the following URL the **TeamName** value is `my-team`: https://example.com/my-team/channels/my-channel . In case of multiple teams, use comma seperated fields. For example `"my-team, my-team-2"` to display the same messages for both `my-team`  and `my-team-2`
 - **DelayInSeconds**: The number of seconds after joining a team that the user receives a welcome message.
 - **Message**: The message posted to the user.
 - (Optional) **AttachmentMessage**: Message text in attachment containing user action buttons.
@@ -100,7 +100,7 @@ To accomplish the above, you can specify the following configuration in your `co
             "com.mattermost.welcomebot": {
                 "WelcomeMessages": [
                     {
-                        "TeamName": "staff",
+                        "TeamName": "staff, management",
                         "DelayInSeconds": 5,
                         "Message": [
                             "### Welcome {{.UserDisplayName}} to the Staff {{.Team.DisplayName}} team!",

--- a/server/command.go
+++ b/server/command.go
@@ -87,12 +87,12 @@ func (p *Plugin) validateCommand(action string, parameters []string) string {
 func (p *Plugin) executeCommandPreview(teamName string, args *model.CommandArgs) {
 	found := false
 	for _, message := range p.getWelcomeMessages() {
-		if message.TeamName == teamName {
+		if strings.Contains(message.TeamName, teamName) {
+			p.postCommandResponse(args, "%s", teamName)
 			if err := p.previewWelcomeMessage(teamName, args, *message); err != nil {
 				p.postCommandResponse(args, "error occurred while processing greeting for team `%s`: `%s`", teamName, err)
 				return
 			}
-
 			found = true
 		}
 	}


### PR DESCRIPTION
#### Summary
I closed the previous PR that had a lot of conflicts and updated the logic here to make the code more simpler and shorter. 
Users can now configure the messages using `team-1, team-2` or `team-1, team-2` and the bot will process the message for those teams when running `/welcomebot preview team-1` or `/welcomebot preview team-2`
#### Ticket Link
https://github.com/mattermost/mattermost-plugin-welcomebot/issues/65
