### PR TITLE
Restrict channel invitations to non-guest accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ where
 - **TeamName**: The teams for which the Welcome Bot sends a message. Must be the team handle used in the URL, in lowercase. For example, in the following URL, the **TeamName** value is `my-team`: https://example.com/my-team/channels/my-channel . In the case of multiple teams, use comma separated fields. For example `"my-team, my-team-2"` to display the same messages for both `my-team` and `my-team-2`
 - **DelayInSeconds**: The number of seconds after joining a team that the user receives a welcome message.
 - **Message**: The message posted to the user.
+- (Optional) **IncludeGuests**: Whether or not to include guest users.
 - (Optional) **AttachmentMessage**: Message text in attachment containing user action buttons.
 - (Optional) **Actions**: Use this to add new team members to channels automatically or based on which action button they pressed.
     - **ActionType**: One of `button` or `automatic`. When `button`: enables uses to select which types of channels they want to join. When `automatic`: the user is automatically added to the specified channels.

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -39,6 +39,9 @@ type ConfigMessage struct {
 
 	// Number of seconds to wait before sending the message
 	DelayInSeconds int
+
+	// Whether or not to include guest users.
+	IncludeGuests bool
 }
 
 // Configuration from config.json

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -40,7 +40,7 @@ type ConfigMessage struct {
 	// Number of seconds to wait before sending the message
 	DelayInSeconds int
 
-	// Whether or not to include guest users.
+	// Whether or not to include guest users
 	IncludeGuests bool
 }
 

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -23,6 +23,9 @@ func (p *Plugin) UserHasJoinedTeam(c *plugin.Context, teamMember *model.TeamMemb
 		for _, name := range teamNamesArr {
 			tn := strings.TrimSpace(name)
 			if tn == data.Team.Name {
+				if data.User.IsGuest() && !message.IncludeGuests {
+					continue
+				}
 				go p.processWelcomeMessage(*data, *message)
 			}
 		}


### PR DESCRIPTION
#### Summary

We hit an issue on our Community server where a guest was getting automatically added to channels they were not supposed to be in when joining a team. 

PR adds an option to conditionally include guests when adding users to channels. I've kept it opt-in (default is false) as it seems to me like the more secure approach but feel free to let me know if you think it's better to have it opt-out (to retain the existing behaviour that is).

Fixes https://github.com/mattermost/mattermost-plugin-welcomebot/issues/63
