### PR TITLE
Add sleep between calls to add user to channels

### DIFF
--- a/server/welcomebot.go
+++ b/server/welcomebot.go
@@ -113,6 +113,7 @@ func (p *Plugin) renderWelcomeMessage(messageTemplate MessageTemplate, configMes
 
 			for _, channelName := range configAction.ChannelsAddedTo {
 				p.joinChannel(action, channelName)
+				time.Sleep(time.Second)
 			}
 		}
 
@@ -200,6 +201,7 @@ func (p *Plugin) processWelcomeMessage(messageTemplate MessageTemplate, configMe
 func (p *Plugin) processActionMessage(messageTemplate MessageTemplate, action *Action, configMessageAction ConfigMessageAction) {
 	for _, channelName := range configMessageAction.ChannelsAddedTo {
 		p.joinChannel(action, channelName)
+		time.Sleep(time.Second)
 	}
 
 	tmpMsg, _ := template.New("Response").Parse(strings.Join(configMessageAction.ActionSuccessfulMessage, "\n"))


### PR DESCRIPTION
#### Summary

There is an issue occurring with the Welcomebot and Channel Actions "automatically add to channel category" feature, where the user is inadvertently having duplicate channel categories created with the same name. We believe is due to a race condition of adding the user to multiple channels semi-simultaneously. More info in the tickets linked below.

This PR adds a sleep in between adding a user to multiple channels, to avoid this situation. A more holistic solution of handling this issue in the core product is discussed in the Jira ticket below, though this PR can resolve this before the core issue is addressed.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-welcomebot/issues/120

https://mattermost.atlassian.net/browse/MM-54003

