### PR TITLE
[MM-382] Add feature to use struct fields in the channel welcome message

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,15 @@ The preview of the configured messages, as well as the creation of a channel wel
 * `/welcomebot help` - Displays usage information.
 * `/welcomebot list` - Lists the teams for which greetings were defined.
 * `/welcomebot preview [team-name]` - Sends ephemeral messages to the user calling the command, with the preview of the welcome message[s] for the given team name and the user that requested the preview.
-* `/welcomebot set_channel_welcome [welcome-message]` - Sets the given text as current's channel welcome message.
+* `/welcomebot set_channel_welcome [welcome-message]` - Sets the given text as current's channel welcome message. You can also include `{{.UserDisplayName}}` and `{{.Channel.DisplayName}}` in the command to print the user joined and the channel display name in the message, respectively. You can insert any variable from the `MessageTemplate` struct, which has the following fields:
+    ```go
+    type MessageTemplate struct {
+        WelcomeBot      *model.User
+        User            *model.User
+        DirectMessage   *model.Channel
+        UserDisplayName string
+    }
+    ```
 * `/welcomebot get_channel_welcome` - Gets the current channel's welcome message.
 * `/welcomebot delete_channel_welcome` - Deletes the current channel's welcome message.
 

--- a/server/message_template.go
+++ b/server/message_template.go
@@ -11,3 +11,11 @@ type MessageTemplate struct {
 	DirectMessage   *model.Channel
 	UserDisplayName string
 }
+
+type ChannelMessageTemplate struct {
+	WelcomeBot      *model.User
+	User            *model.User
+	Channel         *model.Channel
+	DirectMessage   *model.Channel
+	UserDisplayName string
+}

--- a/server/welcomebot.go
+++ b/server/welcomebot.go
@@ -45,6 +45,37 @@ func (p *Plugin) constructMessageTemplate(userID, teamID string) *MessageTemplat
 	return data
 }
 
+func (p *Plugin) constructChannelMessageTemplate(userID, channelID string) *ChannelMessageTemplate {
+	data := &ChannelMessageTemplate{}
+	var err *model.AppError
+
+	if len(userID) > 0 {
+		if data.User, err = p.API.GetUser(userID); err != nil {
+			p.API.LogError("failed to query user", "UserID", userID)
+			return nil
+		}
+	}
+
+	if data.User != nil {
+		if data.DirectMessage, err = p.API.GetDirectChannel(userID, p.botUserID); err != nil {
+			p.API.LogError("failed to query direct message channel", "UserID", userID)
+			return nil
+		}
+	}
+
+	if len(channelID) > 0 {
+		data.Channel, err = p.API.GetChannel(channelID)
+		if err != nil {
+			p.API.LogError("failed to query channel", "ChannelID", channelID)
+			return nil
+		}
+	}
+
+	data.UserDisplayName = data.User.GetDisplayName(model.ShowNicknameFullName)
+
+	return data
+}
+
 func (p *Plugin) getSiteURL() string {
 	siteURL := "http://localhost:8065"
 
@@ -133,18 +164,10 @@ func (p *Plugin) renderWelcomeMessage(messageTemplate MessageTemplate, configMes
 		}
 	}
 
-	tmpMsg, _ := template.New("Response").Parse(strings.Join(configMessage.Message, "\n"))
-	var message bytes.Buffer
-	err := tmpMsg.Execute(&message, messageTemplate)
-	if err != nil {
-		p.API.LogError(
-			"Failed to execute message template",
-			"err", err.Error(),
-		)
-	}
+	message := p.getTemplateMessage(configMessage.Message, messageTemplate)
 
 	post := &model.Post{
-		Message: message.String(),
+		Message: message,
 		UserId:  p.botUserID,
 	}
 
@@ -175,6 +198,17 @@ func (p *Plugin) renderWelcomeMessage(messageTemplate MessageTemplate, configMes
 	}
 
 	return post
+}
+
+func (p *Plugin) getTemplateMessage(data []string, messageTemplate interface{}) string {
+	tmpMsg, _ := template.New("Response").Parse(strings.Join(data, "\n"))
+	var message bytes.Buffer
+	if appErr := tmpMsg.Execute(&message, messageTemplate); appErr != nil {
+		p.API.LogError("Failed to execute channel message template", "Error", appErr.Error())
+		return ""
+	}
+
+	return message.String()
 }
 
 func (p *Plugin) processWelcomeMessage(messageTemplate MessageTemplate, configMessage ConfigMessage) {


### PR DESCRIPTION
#### Summary
- Added feature to use struct fields in the channel welcome message
- Updated readme regarding the above feature

#### Screenshot
![image](https://github.com/mattermost/mattermost-plugin-welcomebot/assets/100013900/1c99e356-9aec-464f-9006-dac0dadeec3a)

#### Ticket Link
Fixes #96 

#### What to test?
- Create a welcome message for a channel while using struct fields (eg: {{.UserDisplayName}}
- Join the channel in which welcome message is created
- Check for the words replaced by the struct fields

#### Checklist
- [x] Completed dev testing
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server pass the checks