### PR TITLE
Fix issue of not being able to add a welcome message in private channel

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -130,7 +130,7 @@ func (p *Plugin) executeCommandSetWelcome(args *model.CommandArgs) {
 		return
 	}
 
-	if channelInfo.Type == model.ChannelTypePrivate {
+	if channelInfo.Type == model.ChannelTypeDirect {
 		p.postCommandResponse(args, "welcome messages are not supported for direct channels")
 		return
 	}

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -39,7 +39,7 @@ func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.Ch
 			mlog.Err(appErr),
 		)
 		return
-	} else if channelInfo.Type == model.ChannelTypePrivate {
+	} else if channelInfo.Type == model.ChannelTypeDirect {
 		return
 	}
 


### PR DESCRIPTION
#### Summary
- Fix issue of not being able to add a welcome message in private channel

#### Ticket Link
Fixes #72 

#### What to test?
- Add a welcome message in a private channel
- Check if the new user added to the above private channel is able to view the message

#### Checklist
- [x] Completed dev testing
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server pass the checks
